### PR TITLE
Fix wrong open Flags

### DIFF
--- a/Vorlesungsbeispiele/MRT1_VL-6_GPIO27_Toggle_Once/main.S
+++ b/Vorlesungsbeispiele/MRT1_VL-6_GPIO27_Toggle_Once/main.S
@@ -65,7 +65,7 @@
 
 // /usr/include/arm-linux-gnueabihf/bits/fcntl-linux.h:# define O_SYNC            04010000
 // /usr/include/arm-linux-gnueabihf/bits/fcntl-linux.h: #define O_RDWR                  02
-.equ OPEN_PARAMETER_SYNC_RDWR, 0x40100002
+.equ OPEN_PARAMETER_SYNC_RDWR, 0x4010002
 
 // /usr/include/arm-linux-gnueabihf/bits/mman-linux.h:#define MAP_SHARED   0x01
 .equ MMAP_PARAMETER_MAP_SHARED, 0x01

--- a/Vorlesungsbeispiele/MRT1_VL-6_GPIO27_Toggle_Once/main.S
+++ b/Vorlesungsbeispiele/MRT1_VL-6_GPIO27_Toggle_Once/main.S
@@ -65,7 +65,7 @@
 
 // /usr/include/arm-linux-gnueabihf/bits/fcntl-linux.h:# define O_SYNC            04010000
 // /usr/include/arm-linux-gnueabihf/bits/fcntl-linux.h: #define O_RDWR                  02
-.equ OPEN_PARAMETER_SYNC_RDWR, 0x4010002
+.equ OPEN_PARAMETER_SYNC_RDWR, 04010002
 
 // /usr/include/arm-linux-gnueabihf/bits/mman-linux.h:#define MAP_SHARED   0x01
 .equ MMAP_PARAMETER_MAP_SHARED, 0x01

--- a/Vorlesungsbeispiele/MRT1_VL-7_GPIOLib/SYSCALL.h
+++ b/Vorlesungsbeispiele/MRT1_VL-7_GPIOLib/SYSCALL.h
@@ -5,8 +5,8 @@
 .equ SYSCALL_OPEN, 5
 // /usr/include/arm-linux-gnueabihf/bits/fcntl-linux.h:# define O_SYNC            04010000
 // /usr/include/arm-linux-gnueabihf/bits/fcntl-linux.h: #define O_RDWR                  02
-.equ OPEN_PARAMETER_SYNC, 0x4010000
-.equ OPEN_PARAMETER_RDWR, 0x0000002
+.equ OPEN_PARAMETER_SYNC, 04010000
+.equ OPEN_PARAMETER_RDWR, 00000002
 .equ OPEN_PARAMETER_SYNC_RDWR, OPEN_PARAMETER_RDWR + OPEN_PARAMETER_SYNC
 
 // /usr/arm-linux-gnueabihf/include/asm/unistd.h: #define __NR_close (__NR_SYSCALL_BASE+6)

--- a/Vorlesungsbeispiele/MRT1_VL-7_GPIOLib/SYSCALL.h
+++ b/Vorlesungsbeispiele/MRT1_VL-7_GPIOLib/SYSCALL.h
@@ -5,8 +5,8 @@
 .equ SYSCALL_OPEN, 5
 // /usr/include/arm-linux-gnueabihf/bits/fcntl-linux.h:# define O_SYNC            04010000
 // /usr/include/arm-linux-gnueabihf/bits/fcntl-linux.h: #define O_RDWR                  02
-.equ OPEN_PARAMETER_SYNC, 0x40100000
-.equ OPEN_PARAMETER_RDWR, 0x00000002
+.equ OPEN_PARAMETER_SYNC, 0x4010000
+.equ OPEN_PARAMETER_RDWR, 0x0000002
 .equ OPEN_PARAMETER_SYNC_RDWR, OPEN_PARAMETER_RDWR + OPEN_PARAMETER_SYNC
 
 // /usr/arm-linux-gnueabihf/include/asm/unistd.h: #define __NR_close (__NR_SYSCALL_BASE+6)

--- a/Vorlesungsbeispiele/MRT1_VL-8_SPIBasics/SYSCALL.h
+++ b/Vorlesungsbeispiele/MRT1_VL-8_SPIBasics/SYSCALL.h
@@ -5,8 +5,8 @@
 .equ SYSCALL_OPEN, 5
 // /usr/include/arm-linux-gnueabihf/bits/fcntl-linux.h:# define O_SYNC            04010000
 // /usr/include/arm-linux-gnueabihf/bits/fcntl-linux.h: #define O_RDWR                  02
-.equ OPEN_PARAMETER_SYNC, 0x4010000
-.equ OPEN_PARAMETER_RDWR, 0x0000002
+.equ OPEN_PARAMETER_SYNC, 04010000
+.equ OPEN_PARAMETER_RDWR, 00000002
 .equ OPEN_PARAMETER_SYNC_RDWR, OPEN_PARAMETER_RDWR + OPEN_PARAMETER_SYNC
 
 // /usr/arm-linux-gnueabihf/include/asm/unistd.h: #define __NR_close (__NR_SYSCALL_BASE+6)

--- a/Vorlesungsbeispiele/MRT1_VL-8_SPIBasics/SYSCALL.h
+++ b/Vorlesungsbeispiele/MRT1_VL-8_SPIBasics/SYSCALL.h
@@ -5,8 +5,8 @@
 .equ SYSCALL_OPEN, 5
 // /usr/include/arm-linux-gnueabihf/bits/fcntl-linux.h:# define O_SYNC            04010000
 // /usr/include/arm-linux-gnueabihf/bits/fcntl-linux.h: #define O_RDWR                  02
-.equ OPEN_PARAMETER_SYNC, 0x40100000
-.equ OPEN_PARAMETER_RDWR, 0x00000002
+.equ OPEN_PARAMETER_SYNC, 0x4010000
+.equ OPEN_PARAMETER_RDWR, 0x0000002
 .equ OPEN_PARAMETER_SYNC_RDWR, OPEN_PARAMETER_RDWR + OPEN_PARAMETER_SYNC
 
 // /usr/arm-linux-gnueabihf/include/asm/unistd.h: #define __NR_close (__NR_SYSCALL_BASE+6)

--- a/Vorlesungsbeispiele/MRT1_VL-9_TempLightFlat/SYSCALL.h
+++ b/Vorlesungsbeispiele/MRT1_VL-9_TempLightFlat/SYSCALL.h
@@ -11,8 +11,8 @@
 .equ SYSCALL_OPEN, 5
 // aus:  /usr/include/arm-linux-gnueabihf/bits/fcntl-linux.h:# define O_SYNC            04010000
 // aus:  /usr/include/arm-linux-gnueabihf/bits/fcntl-linux.h: #define O_RDWR                  02
-.equ OPEN_PARAMETER_SYNC, 0x4010000
-.equ OPEN_PARAMETER_RDWR, 0x0000002
+.equ OPEN_PARAMETER_SYNC, 04010000
+.equ OPEN_PARAMETER_RDWR, 00000002
 .equ OPEN_PARAMETER_SYNC_RDWR, OPEN_PARAMETER_RDWR + OPEN_PARAMETER_SYNC
 
 // aus:  /usr/arm-linux-gnueabihf/include/asm/unistd.h: #define __NR_close (__NR_SYSCALL_BASE+6)

--- a/Vorlesungsbeispiele/MRT1_VL-9_TempLightFlat/SYSCALL.h
+++ b/Vorlesungsbeispiele/MRT1_VL-9_TempLightFlat/SYSCALL.h
@@ -11,8 +11,8 @@
 .equ SYSCALL_OPEN, 5
 // aus:  /usr/include/arm-linux-gnueabihf/bits/fcntl-linux.h:# define O_SYNC            04010000
 // aus:  /usr/include/arm-linux-gnueabihf/bits/fcntl-linux.h: #define O_RDWR                  02
-.equ OPEN_PARAMETER_SYNC, 0x40100000
-.equ OPEN_PARAMETER_RDWR, 0x00000002
+.equ OPEN_PARAMETER_SYNC, 0x4010000
+.equ OPEN_PARAMETER_RDWR, 0x0000002
 .equ OPEN_PARAMETER_SYNC_RDWR, OPEN_PARAMETER_RDWR + OPEN_PARAMETER_SYNC
 
 // aus:  /usr/arm-linux-gnueabihf/include/asm/unistd.h: #define __NR_close (__NR_SYSCALL_BASE+6)


### PR DESCRIPTION
Die open Flags haben eine 0 zu viel
Vergleich: https://elixir.bootlin.com/linux/v5.3.10/source/tools/include/uapi/asm-generic/fcntl.h#L80